### PR TITLE
feat: add pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools >= 77.0.3"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "slopepath"
+version = "1.0.0"
+description = "The exact slope path"
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = ["numpy>=1.12", "numba", "scipy>=0.18.0"]
+
+[project.optional-dependencies]
+experiments = ["jupyterlab", "matplotlib", "pandas"]
+
+[tool.setuptools]
+packages = ["modules"]


### PR DESCRIPTION
This project is hard to install without some infrastructure. This PR adds a `pyproject.toml` file that makes it possible to install the package via pip.

Note that it is still a bit awkward that the main module of this package is called `modules`, which means that one needs to do `from modules import path_solver` etc, which is perhaps not ideal.

There are many other fields in the `pyproject.toml` specification that I've left untouched here, but you might want to consider at least adding some author information and a license. In fact I'll open up a new issue regarding the license, which is necessary if someone wants to extend your work.